### PR TITLE
Accept ecto 2.* and above instead of 2.* only.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule Ecto.ULID.Mixfile do
 
   defp deps do
     [
-      {:ecto, "~> 2.0"},
+      {:ecto, "~> 2.0 or ~> 3.0"},
       {:benchfella, "~> 0.3.5", only: [:dev, :test]},
       {:ex_doc, "~> 0.16", only: :dev, runtime: false},
     ]


### PR DESCRIPTION
Added as it in my ecto 3.0 project, it looks like it is also compatible with ecto 3.* version.

wdyt ?
