### PR TITLE
change :milli_seconds to :millisecond deprecation

### DIFF
--- a/lib/ecto/ulid.ex
+++ b/lib/ecto/ulid.ex
@@ -57,7 +57,7 @@ defmodule Ecto.ULID do
 
   * `timestamp`: A Unix timestamp with millisecond precision.
   """
-  def generate(timestamp \\ System.system_time(:milli_seconds)) do
+  def generate(timestamp \\ System.system_time(:millisecond)) do
     {:ok, ulid} = encode(bingenerate(timestamp))
     ulid
   end
@@ -72,7 +72,7 @@ defmodule Ecto.ULID do
 
   * `timestamp`: A Unix timestamp with millisecond precision.
   """
-  def bingenerate(timestamp \\ System.system_time(:milli_seconds)) do
+  def bingenerate(timestamp \\ System.system_time(:millisecond)) do
     <<timestamp::unsigned-size(48), :crypto.strong_rand_bytes(10)::binary>>
   end
 

--- a/test/ecto/ulid_test.exs
+++ b/test/ecto/ulid_test.exs
@@ -23,7 +23,7 @@ defmodule Ecto.ULIDTest do
   # bingenerate/0
 
   test "bingenerate/0 encodes milliseconds in first 48 bits" do
-    now = System.system_time(:milli_seconds)
+    now = System.system_time(:millisecond)
     <<time::48, _random::80>> = Ecto.ULID.bingenerate()
 
     assert_in_delta now, time, 10


### PR DESCRIPTION
Removes `warning: deprecated time unit: :milli_seconds. A time unit should be :second, :millisecond, :microsecond, :nanosecond, or a positive integer` in elixir 1.8