### PR TITLE
Support Ecto 3.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,20 @@ cache:
     - _build
 matrix:
   include:
-    - elixir: 1.8.0
-      otp_release: 21.2
+    - elixir: 1.11.2
+      otp_release: 23.0
+      env: MIX_EXS=ci/mix-ecto-3.0.exs
+    - elixir: 1.10.4
+      otp_release: 22.3
+      env: MIX_EXS=ci/mix-ecto-3.0.exs
+    - elixir: 1.9.4
+      otp_release: 22.3
+      env: MIX_EXS=ci/mix-ecto-3.0.exs
+    - elixir: 1.8.2
+      otp_release: 22.3
       env: MIX_EXS=ci/mix-ecto-3.0.exs
     - elixir: 1.7.4
-      otp_release: 21.0
+      otp_release: 22.3
       env: MIX_EXS=ci/mix-ecto-3.0.exs
     - elixir: 1.6.6
       otp_release: 20.3

--- a/lib/ecto/ulid.ex
+++ b/lib/ecto/ulid.ex
@@ -3,7 +3,11 @@ defmodule Ecto.ULID do
   An Ecto type for ULID strings.
   """
 
+  # replace with `use Ecto.Type` after Ecto 3.2.0 is required
   @behaviour Ecto.Type
+  # and remove both of these functions
+  def embed_as(_), do: :self
+  def equal?(term1, term2), do: term1 == term2
 
   @doc """
   The underlying schema type.


### PR DESCRIPTION
Ecto 3.2.0 requires two new `Ecto.Type` callbacks, [`embed_as/1`](https://github.com/elixir-ecto/ecto/commit/5a05dd9784f3cc5654c1c905fb79e2c86840bcc2) and [`equal?/2`](https://github.com/elixir-ecto/ecto/pull/2651).

```
warning: function embed_as/1 required by behaviour Ecto.Type is not implemented (in module Ecto.ULID)
  lib/ecto/ulid.ex:1: Ecto.ULID (module)

warning: function equal?/2 required by behaviour Ecto.Type is not implemented (in module Ecto.ULID)
  lib/ecto/ulid.ex:1: Ecto.ULID (module)
```

[`use Ecto.Type`](https://github.com/elixir-ecto/ecto/commit/c040b7c0f5bc5ac244cf3f4c0272ed684d9e8c52) was also added to provide default implementations of those callbacks.

This pull request adds those implementations to `Ecto.ULID` until Ecto 3.2.0 is required.