### PR TITLE
Adding type `t`

### DIFF
--- a/lib/ecto/ulid.ex
+++ b/lib/ecto/ulid.ex
@@ -5,6 +5,11 @@ defmodule Ecto.ULID do
 
   @behaviour Ecto.Type
 
+  @typedoc """
+  A hex-encoded ULID string.
+  """
+  @type t :: <<_::208>>
+
   @doc """
   The underlying schema type.
   """


### PR DESCRIPTION
Adding type `t`, similarly to [how ecto/uuid implements it](https://github.com/elixir-ecto/ecto/blob/6a74f82a868b62a4ce2208d017569dd650edf101/lib/ecto/uuid.ex#L11).

This will allow https://github.com/msz/hammox to match typespecs in behaviours.