### PR TITLE
Fix warning when using ecto 3.5.

### DIFF
--- a/lib/ecto/ulid.ex
+++ b/lib/ecto/ulid.ex
@@ -3,7 +3,7 @@ defmodule Ecto.ULID do
   An Ecto type for ULID strings.
   """
 
-  @behaviour Ecto.Type
+  use Ecto.Type
 
   @doc """
   The underlying schema type.


### PR DESCRIPTION
Fixed some warning that cause failure because missing embed_as implementation.

```
==> ecto_ulid
Compiling 1 file (.ex)
warning: function embed_as/1 required by behaviour Ecto.Type is not implemented (in module Ecto.ULID)
  lib/ecto/ulid.ex:1: Ecto.ULID (module)
warning: function equal?/2 required by behaviour Ecto.Type is not implemented (in module Ecto.ULID)
  lib/ecto/ulid.ex:1: Ecto.ULID (module)
```


did the same fix as seen here :https://github.com/adam12/ecto_network/issues/17