### PR TITLE
Misc doc changes

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,5 @@
+# Used by "mix format"
+[
+  import_deps: [:ecto],
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-mix.lock
-bench/snapshots/
-
 # The directory Mix will write compiled artifacts to.
 /_build/
 
@@ -10,7 +7,7 @@ bench/snapshots/
 # The directory Mix downloads your dependencies sources to.
 /deps/
 
-# Where 3rd-party dependencies like ExDoc output generated docs.
+# Where third-party dependencies like ExDoc output generated docs.
 /doc/
 
 # Ignore .fetch files in case you like to edit your project deps locally.
@@ -21,3 +18,13 @@ erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+# Ignore package tarball (built via "mix hex.build").
+ecto_ulid-*.tar
+
+# Temporary files, for example, from tests.
+/tmp/
+
+# Misc.
+mix.lock
+bench/snapshots/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.3.0 (2021-04-20)
+### Changed
+* ([#5](https://github.com/TheRealReal/ecto-ulid/pull/4))
+  Support Ecto 3.2.0.
+
 ## 0.2.0 (2019-01-17)
 ### Breaking Changes
 * Minimum supported Elixir is now 1.4.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,5 @@
+# MIT License
+
 Copyright (c) 2018 The RealReal, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Ecto.ULID
 
+[![Module Version](https://img.shields.io/hexpm/v/ecto_ulid.svg)](https://hex.pm/packages/ecto_ulid)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/ecto_ulid/)
+[![Total Download](https://img.shields.io/hexpm/dt/ecto_ulid.svg)](https://hex.pm/packages/ecto_ulid)
+[![License](https://img.shields.io/hexpm/l/ecto_ulid.svg)](https://github.com/TheRealReal/ecto-ulid/blob/master/LICENSE.md)
+[![Last Updated](https://img.shields.io/github/last-commit/TheRealReal/ecto-ulid.svg)](https://github.com/TheRealReal/ecto-ulid/commits/master)
+
 An `Ecto.Type` implementation of [ULID](https://github.com/ulid/spec).
 
 `Ecto.ULID` should be compatible anywhere that `Ecto.UUID` is supported. It has been confirmed to
@@ -32,6 +38,8 @@ on your system.
 The following are results from running the benchmark on an AMD Ryzen Threadripper 1950X:
 
 ```
+mix bench
+...
 benchmark name iterations   average time
 cast/1           10000000   0.25 µs/op
 dump/1           10000000   0.50 µs/op
@@ -49,7 +57,7 @@ primary key in a database table, but it can be used for other columns just as ea
 
 ### Install
 
-Install `ecto_ulid` from Hex by adding it to the dependencies in `mix.exs`:
+Install `:ecto_ulid` from Hex by adding it to the dependencies in `mix.exs`:
 
 ```elixir
 defp deps do
@@ -119,8 +127,9 @@ Ecto.ULID.bingenerate() #=> <<1, 95, 194, 60, 108, 73, 209, 114, 136, 236, 133, 
 To backfill old data, it may be helpful to pass a timestamp to `generate/1` or `bingenerate/1`. See
 the [API documentation](https://hexdocs.pm/ecto_ulid) for more details.
 
-## License
+## Copyright and License
 
-Copyright © 2018 The RealReal, Inc.
+Copyright (c) 2018 The RealReal, Inc.
 
-Distributed under the [MIT License](./LICENSE).
+This library is released under the MIT License. See the [LICENSE.md](./LICENSE.md) file
+for further details.

--- a/mix.exs
+++ b/mix.exs
@@ -1,19 +1,19 @@
 defmodule Ecto.ULID.Mixfile do
   use Mix.Project
 
+  @source_url "https://github.com/TheRealReal/ecto-ulid"
+  @version "0.3.0"
+
   def project do
     [
       app: :ecto_ulid,
       version: "0.3.0",
       elixir: "~> 1.4",
       start_permanent: Mix.env == :prod,
-      deps: deps(),
       name: "Ecto.ULID",
-      description: "An Ecto.Type implementation of ULID.",
+      deps: deps(),
       package: package(),
-      source_url: "https://github.com/TheRealReal/ecto-ulid",
-      homepage_url: "https://github.com/TheRealReal/ecto-ulid",
-      docs: [main: "Ecto.ULID"],
+      docs: docs()
     ]
   end
 
@@ -25,9 +25,13 @@ defmodule Ecto.ULID.Mixfile do
 
   defp package do
     [
+      description: "An Ecto.Type implementation of ULID.",
       maintainers: ["David Cuddeback"],
       licenses: ["MIT"],
-      links: %{"GitHub" => "https://github.com/TheRealReal/ecto-ulid"},
+      links: %{
+        "Changelog" => "https://hexdocs.pm/ecto_ulid/changelog.html",
+        "GitHub" => @source_url
+      },
     ]
   end
 
@@ -35,7 +39,21 @@ defmodule Ecto.ULID.Mixfile do
     [
       {:ecto, "~> 2.0 or ~> 3.0"},
       {:benchfella, "~> 0.3.5", only: [:dev, :test]},
-      {:ex_doc, "~> 0.16", only: :dev, runtime: false},
+      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
+    ]
+  end
+
+  defp docs do
+    [
+      extras: [
+        "CHANGELOG.md": [title: "Changelog"],
+        "LICENSE.md": [title: "License"],
+        "README.md": [title: "Overview"]
+      ],
+      main: "readme",
+      source_url: @source_url,
+      source_ref: "v#{@version}",
+      formatters: ["html"]
     ]
   end
 end


### PR DESCRIPTION
Besides other documentation changes, this commit ensures the generated
HTML doc for HexDocs.pm will become the source of truth for this Elixir
library and leverage on latest features of ExDoc.