### PR TITLE
Add Firebase base64 variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ecto.ULID
 
-An `Ecto.Type` implementation of [ULID](https://github.com/ulid/spec).
+An `Ecto.ParameterizedType` implementation of [ULID](https://github.com/ulid/spec).
 
 `Ecto.ULID` should be compatible anywhere that `Ecto.UUID` is supported. It has been confirmed to
 work with PostgreSQL and MySQL on Ecto 2.x and 3.x.  Ecto 1.x is *not* supported.
@@ -105,6 +105,20 @@ end
 
 `Ecto.ULID` supports `autogenerate: true` as well as `autogenerate: false` when used as the primary
 key.
+
+`Ecto.ULID` also supports `variant: :b64` as well as `variant: :push` that follows the compact 20-char string encoding standard defined in [Firebase Push Key](https://firebase.googleblog.com/2015/02/the-2120-ways-to-ensure-unique_68.html). Just like the default Crockford base32 encoding, both variants use a modified base64 alphabet to ensure the IDs will still sort correctly when ordered lexicographically. Do note that the `:push` variant encodes only 120-bits, but is otherwise interoperable with the standard 128-bit binary ULID (by having the 1st-byte of the random component set to 0, we achieve a more efficient base64 encoding that saves 2 characters).
+
+```elixir
+defmodule MyApp.Event do
+  use Ecto.Schema
+
+  @primary_key {:id, Ecto.ULID, autogenerate: false, variant: :b64}
+  @foreign_key_type Ecto.ULID
+  schema "events" do
+    # more columns ...
+  end
+end
+```
 
 ### Application Usage
 

--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ The following are results from running the benchmark on an AMD Ryzen Threadrippe
 
 ```
 benchmark name iterations   average time
-cast/1           10000000   0.25 µs/op
+cast/2           10000000   0.25 µs/op
 dump/1           10000000   0.50 µs/op
-load/1           10000000   0.55 µs/op
-bingenerate/0    10000000   0.93 µs/op
-generate/0        1000000   1.55 µs/op
+load/2           10000000   0.55 µs/op
+bingenerate/1    10000000   0.93 µs/op
+generate/2        1000000   1.55 µs/op
 ```
 
 ## Usage
@@ -108,7 +108,7 @@ key.
 
 ### Application Usage
 
-A ULID can be generated in string or binary format by calling `generate/0` or `bingenerate/0`. This
+A ULID can be generated in string or binary format by calling `generate/2` or `bingenerate/1`. This
 can be useful when generating ULIDs to send to external systems:
 
 ```elixir

--- a/bench/ulid_bench.exs
+++ b/bench/ulid_bench.exs
@@ -1,25 +1,59 @@
 defmodule ULIDBench do
   use Benchfella
 
-  bench "generate/0" do
+  bench "generate/2" do
     Ecto.ULID.generate()
     nil
   end
 
-  bench "bingenerate/0" do
+  bench "generate/2 (:b64)" do
+    Ecto.ULID.generate(:b64)
+    nil
+  end
+
+  bench "generate/2 (:push)" do
+    Ecto.ULID.generate(:push)
+    nil
+  end
+
+  bench "bingenerate/1" do
     Ecto.ULID.bingenerate()
     nil
   end
 
-  bench "cast/1" do
+  bench "cast/2" do
     Ecto.ULID.cast("01C0M0Y7BG2NMB15VVVJH807F3")
+  end
+
+  bench "cast/2 (:b64)" do
+    Ecto.ULID.cast("-0N1VE6M-KPA1MTxmXV0rY")
+  end
+
+  bench "cast/2 (:push)" do
+    Ecto.ULID.cast("-L-c2lpkPA1MTxmXV0rY")
   end
 
   bench "dump/1" do
     Ecto.ULID.dump("01C0M0Y7BG2NMB15VVVJH807F3")
   end
 
-  bench "load/1" do
+  bench "dump/1 (:b64)" do
+    Ecto.ULID.dump("-0N1VE6M-KPA1MTxmXV0rY")
+  end
+
+  bench "dump/1 (:push)" do
+    Ecto.ULID.dump("-L-c2lpkPA1MTxmXV0rY")
+  end
+
+  bench "load/2" do
     Ecto.ULID.load(<<1, 96, 40, 15, 29, 112, 21, 104, 176, 151, 123, 220, 162, 128, 29, 227>>)
+  end
+
+  bench "load/2 (:b64)" do
+    Ecto.ULID.load(<<1, 96, 40, 15, 29, 112, 21, 104, 176, 151, 123, 220, 162, 128, 29, 227>>, :b64)
+  end
+
+  bench "load/2 (:push)" do
+    Ecto.ULID.load(<<1, 96, 40, 15, 29, 112, 21, 104, 176, 151, 123, 220, 162, 128, 29, 227>>, :push)
   end
 end

--- a/lib/ecto/ulid.ex
+++ b/lib/ecto/ulid.ex
@@ -48,6 +48,12 @@ defmodule Ecto.ULID do
   def load(<<_::unsigned-size(128)>> = bytes), do: encode(bytes)
   def load(_), do: :error
 
+  @doc """
+  Converts a binary ULID into a Firebase Base64 encoded string.
+  """
+  def load64(<<_::unsigned-size(128)>> = bytes), do: encode64(bytes)
+  def load64(_), do: :error
+
   @doc false
   def autogenerate, do: generate()
 
@@ -91,7 +97,18 @@ defmodule Ecto.ULID do
   end
   defp encode(_), do: :error
 
-  @compile {:inline, e: 1}
+  defp encode64(<< b1::2,  b2::6,  b3::6,  b4::6,  b5::6,  b6::6,  b7::6,  b8::6,  b9::6, b10::6, b11::6, b12::6, b13::6,
+                b14::6, b15::6, b16::6, b17::6, b18::6, b19::6, b20::6, b21::6, b22::6>>) do
+    <<e64(b1), e64(b2), e64(b3), e64(b4), e64(b5), e64(b6), e64(b7), e64(b8), e64(b9), e64(b10), e64(b11), e64(b12), e64(b13),
+      e64(b14), e64(b15), e64(b16), e64(b17), e64(b18), e64(b19), e64(b20), e64(b21), e64(b22)>>
+  catch
+    :error -> :error
+  else
+    encoded -> {:ok, encoded}
+  end
+  defp encode64(_), do: :error
+
+  @compile {:inline, e: 1, e64: 1}
 
   defp e(0), do: ?0
   defp e(1), do: ?1
@@ -125,6 +142,71 @@ defmodule Ecto.ULID do
   defp e(29), do: ?X
   defp e(30), do: ?Y
   defp e(31), do: ?Z
+
+  defp e64(0), do: ?-
+  defp e64(1), do: ?0
+  defp e64(2), do: ?1
+  defp e64(3), do: ?2
+  defp e64(4), do: ?3
+  defp e64(5), do: ?4
+  defp e64(6), do: ?5
+  defp e64(7), do: ?6
+  defp e64(8), do: ?7
+  defp e64(9), do: ?8
+  defp e64(10), do: ?9
+  defp e64(11), do: ?A
+  defp e64(12), do: ?B
+  defp e64(13), do: ?C
+  defp e64(14), do: ?D
+  defp e64(15), do: ?E
+  defp e64(16), do: ?F
+  defp e64(17), do: ?G
+  defp e64(18), do: ?H
+  defp e64(19), do: ?I
+  defp e64(20), do: ?J
+  defp e64(21), do: ?K
+  defp e64(22), do: ?L
+  defp e64(23), do: ?M
+  defp e64(24), do: ?N
+  defp e64(25), do: ?O
+  defp e64(26), do: ?P
+  defp e64(27), do: ?Q
+  defp e64(28), do: ?R
+  defp e64(29), do: ?S
+  defp e64(30), do: ?T
+  defp e64(31), do: ?U
+  defp e64(32), do: ?V
+  defp e64(33), do: ?W
+  defp e64(34), do: ?X
+  defp e64(35), do: ?Y
+  defp e64(36), do: ?Z
+  defp e64(37), do: ?_
+  defp e64(38), do: ?a
+  defp e64(39), do: ?b
+  defp e64(40), do: ?c
+  defp e64(41), do: ?d
+  defp e64(42), do: ?e
+  defp e64(43), do: ?f
+  defp e64(44), do: ?g
+  defp e64(45), do: ?h
+  defp e64(46), do: ?i
+  defp e64(47), do: ?j
+  defp e64(48), do: ?k
+  defp e64(49), do: ?l
+  defp e64(50), do: ?m
+  defp e64(51), do: ?n
+  defp e64(52), do: ?o
+  defp e64(53), do: ?p
+  defp e64(54), do: ?q
+  defp e64(55), do: ?r
+  defp e64(56), do: ?s
+  defp e64(57), do: ?t
+  defp e64(58), do: ?u
+  defp e64(59), do: ?v
+  defp e64(60), do: ?w
+  defp e64(61), do: ?x
+  defp e64(62), do: ?y
+  defp e64(63), do: ?z
 
   defp decode(<< c1::8,  c2::8,  c3::8,  c4::8,  c5::8,  c6::8,  c7::8,  c8::8,  c9::8, c10::8, c11::8, c12::8, c13::8,
                 c14::8, c15::8, c16::8, c17::8, c18::8, c19::8, c20::8, c21::8, c22::8, c23::8, c24::8, c25::8, c26::8>>) do

--- a/test/ecto/ulid_test.exs
+++ b/test/ecto/ulid_test.exs
@@ -147,4 +147,19 @@ defmodule Ecto.ULIDTest do
   test "load/2 returns error when data is too long" do
     assert Ecto.ULID.load(<<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>) == :error
   end
+
+  defmodule SchemaWithUlidAsPrimaryKey do
+    use Ecto.Schema
+
+    @primary_key {:id, Ecto.ULID,
+                  autogenerate: true, variant: :b64}
+    schema "" do
+    end
+  end
+
+  test "init primary key field" do
+    assert SchemaWithUlidAsPrimaryKey.__schema__(:autogenerate_id) == nil
+    assert SchemaWithUlidAsPrimaryKey.__schema__(:autogenerate) ==
+      [{[:id], {Ecto.ULID, :autogenerate, [%{variant: :b64}]}}]
+  end
 end

--- a/test/ecto/ulid_test.exs
+++ b/test/ecto/ulid_test.exs
@@ -3,76 +3,78 @@ defmodule Ecto.ULIDTest do
 
   @binary <<1, 95, 194, 60, 108, 73, 209, 114, 136, 236, 133, 115, 106, 195, 145, 22>>
   @encoded "01BZ13RV29T5S8HV45EDNC748P"
+  @encoded_b64 "-0Mw7wQ3bGRcYgWMCekt3L"
+  @encoded_push "-Kz1E5l8RcYgWMCekt3L"
 
-  # generate/0
+  # generate/2
 
-  test "generate/0 encodes milliseconds in first 10 characters" do
+  test "generate/2 encodes milliseconds in first 10 characters" do
     # test case from ULID README: https://github.com/ulid/javascript#seed-time
     <<encoded::bytes-size(10), _rest::bytes-size(16)>> = Ecto.ULID.generate(1469918176385)
 
     assert encoded == "01ARYZ6S41"
   end
 
-  test "generate/0 generates unique identifiers" do
+  test "generate/2 generates unique identifiers" do
     ulid1 = Ecto.ULID.generate()
     ulid2 = Ecto.ULID.generate()
 
     assert ulid1 != ulid2
   end
 
-  # bingenerate/0
+  # bingenerate/1
 
-  test "bingenerate/0 encodes milliseconds in first 48 bits" do
+  test "bingenerate/1 encodes milliseconds in first 48 bits" do
     now = System.system_time(:millisecond)
     <<time::48, _random::80>> = Ecto.ULID.bingenerate()
 
     assert_in_delta now, time, 10
   end
 
-  test "bingenerate/0 generates unique identifiers" do
+  test "bingenerate/1 generates unique identifiers" do
     ulid1 = Ecto.ULID.bingenerate()
     ulid2 = Ecto.ULID.bingenerate()
 
     assert ulid1 != ulid2
   end
 
-  # cast/1
+  # cast/2
 
-  test "cast/1 returns valid ULID" do
+  test "cast/2 returns valid ULID" do
     {:ok, ulid} = Ecto.ULID.cast(@encoded)
     assert ulid == @encoded
   end
 
-  test "cast/1 returns ULID for encoding of correct length" do
+  test "cast/2 returns ULID for encoding of correct length" do
     {:ok, ulid} = Ecto.ULID.cast("00000000000000000000000000")
     assert ulid == "00000000000000000000000000"
   end
 
-  test "cast/1 returns error when encoding is too short" do
+  test "cast/2 returns error when encoding is too short" do
     assert Ecto.ULID.cast("0000000000000000000000000") == :error
   end
 
-  test "cast/1 returns error when encoding is too long" do
+  test "cast/2 returns error when encoding is too long" do
     assert Ecto.ULID.cast("000000000000000000000000000") == :error
   end
 
-  test "cast/1 returns error when encoding contains letter I" do
+  test "cast/2 returns error when encoding contains letter I" do
     assert Ecto.ULID.cast("I0000000000000000000000000") == :error
   end
 
-  test "cast/1 returns error when encoding contains letter L" do
+  test "cast/2 returns error when encoding contains letter L" do
     assert Ecto.ULID.cast("L0000000000000000000000000") == :error
   end
 
-  test "cast/1 returns error when encoding contains letter O" do
+  test "cast/2 returns error when encoding contains letter O" do
     assert Ecto.ULID.cast("O0000000000000000000000000") == :error
   end
 
-  test "cast/1 returns error when encoding contains letter U" do
+  test "cast/2 returns error when encoding contains letter U" do
     assert Ecto.ULID.cast("U0000000000000000000000000") == :error
   end
 
-  test "cast/1 returns error for invalid encoding" do
+  test "cast/2 returns error for invalid encoding" do
     assert Ecto.ULID.cast("$0000000000000000000000000") == :error
   end
 
@@ -116,23 +118,33 @@ defmodule Ecto.ULIDTest do
     assert Ecto.ULID.dump("$0000000000000000000000000") == :error
   end
 
-  # load/1
+  # load/2
 
-  test "load/1 encodes binary as ULID" do
+  test "load/2 encodes binary as Base32" do
     {:ok, encoded} = Ecto.ULID.load(@binary)
     assert encoded == @encoded
   end
 
-  test "load/1 encodes binary of correct length" do
+  test "load/2 encodes binary as Base64" do
+    {:ok, encoded} = Ecto.ULID.load(@binary, :b64)
+    assert encoded == @encoded_b64
+  end
+
+  test "load/2 encodes binary as Firebase-Push-Key" do
+    {:ok, encoded} = Ecto.ULID.load(@binary, :push)
+    assert encoded == @encoded_push
+  end
+
+  test "load/2 encodes binary of correct length" do
     {:ok, encoded} = Ecto.ULID.load(<<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>)
     assert encoded == "00000000000000000000000000"
   end
 
-  test "load/1 returns error when data is too short" do
+  test "load/2 returns error when data is too short" do
     assert Ecto.ULID.load(<<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>) == :error
   end
 
-  test "load/1 returns error when data is too long" do
+  test "load/2 returns error when data is too long" do
     assert Ecto.ULID.load(<<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>) == :error
   end
 end


### PR DESCRIPTION
Not sure if this is desired, but just wondering if there is any interest in merging our fork that allows a variant of `Ecto.Type` during compile-time, which offers more encoding options than just the default Crockford standard.

Performance is maintained as seen from the `mix bench` results.